### PR TITLE
Mark params as public to mimic public header definition

### DIFF
--- a/src/Products/PythonScripts/PythonScript.py
+++ b/src/Products/PythonScripts/PythonScript.py
@@ -129,12 +129,12 @@ class PythonScript(Script, Historical, Cacheable):
 
     security.declareObjectProtected('View')
     security.declareProtected('View', '__call__')
-
+    security.declarePublic('params')
     security.declareProtected(
         'View management screens',
         'ZPythonScriptHTML_editForm', 'manage_main', 'read',
         'ZScriptHTML_tryForm', 'PrincipiaSearchSource',
-        'document_src', 'params', 'body', 'get_filepath')
+        'document_src', 'body', 'get_filepath')
 
     ZPythonScriptHTML_editForm = DTMLFile('www/pyScriptEdit', globals())
     manage = manage_main = ZPythonScriptHTML_editForm


### PR DESCRIPTION
Scripts are targets of URL calls thus even unauthorised user should be able to see necessary arguments to call such a function. The only hidden thing is the implementation (following .h/.c separation).